### PR TITLE
feat(auth): Enhance JWT authentication and authorization

### DIFF
--- a/backend/apps/auth/schemas.py
+++ b/backend/apps/auth/schemas.py
@@ -8,10 +8,13 @@ class UserCreate(BaseModel):
 
 class UserOut(BaseModel):
     id: UUID
+    username: str
     email: EmailStr
-    password: str
     role: str
     is_verified: bool  # Indicates if the user's email is verified
+
+class UserInDB(UserOut):
+    password: str
 
 class Token(BaseModel):
     access_token: str
@@ -32,3 +35,6 @@ class RefreshTokenRequest(BaseModel):
 class AccessTokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+
+class LogoutRequest(BaseModel):
+    refresh_token: str


### PR DESCRIPTION
This commit implements several improvements to the JWT authentication and authorization system based on a security review:

1.  **Prevent Hashed Password Exposure:**
    - Modified the `UserOut` schema to remove the `password` field, preventing accidental exposure of hashed passwords in API responses.
    - Introduced a `UserInDB` schema for internal use that includes the hashed password, used during authentication.
    - Updated services and routes to use these new schemas appropriately.
    - Added `username` field to `UserOut` and `UserInDB` for consistency.

2.  **Harmonized Token Blacklisting Service:**
    - Refactored the `blacklist_token` service in `apps.auth.services` to accept `jti` and `expires_at` directly, simplifying its logic by removing internal token decoding.
    - Updated the `/logout` route to provide these parameters.

3.  **Full Logout via Refresh Token Blacklisting:**
    - Modified the `/logout` endpoint to require you to submit your refresh token in the request body.
    - Both the current access token (from headers) and the provided refresh token are now blacklisted upon logout. This ensures a more complete invalidation of your session.

4.  **Refresh Token Blacklist Check:**
    - Enhanced the `/refresh` endpoint to check if the provided refresh token's JTI is present in the blacklist.
    - If a refresh token is found to be blacklisted, a new access token will not be issued, preventing revoked tokens from being used.

5.  **Blacklist Cleanup Recommendation:**
    - Added comments in `apps.auth.services.py` detailing the necessity of a periodic cleanup mechanism for the `token_blacklist` table to remove expired JTIs and manage database size.

These changes strengthen token validation, improve logout procedures, and enhance the overall security posture of the authentication system.